### PR TITLE
meson: install btrfs-fuse binary

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -24,4 +24,4 @@ compression_deps = [zlib_dep, lzo_dep, zstd_dep]
 fuse_dep = dependency('fuse3')
 
 deps = [uuid_dep, hash_deps, compression_deps, fuse_dep]
-executable('btrfs-fuse', src, dependencies: deps)
+executable('btrfs-fuse', src, dependencies: deps, install: true)


### PR DESCRIPTION
This is needed for `meson install` to work properly.