### PR TITLE
Fix static_assert issue in C11

### DIFF
--- a/ondisk_format.h
+++ b/ondisk_format.h
@@ -225,7 +225,7 @@ struct btrfs_super_block {
 	u8 __unused5[1237];
 } __attribute__ ((__packed__));
 
-static_assert(sizeof(struct btrfs_super_block) == BTRFS_SUPER_INFO_SIZE);
+static_assert(sizeof(struct btrfs_super_block) == BTRFS_SUPER_INFO_SIZE, "Superblock size mismatch!");
 
 /*
  * Btrfs metadata blocks has two different types:


### PR DESCRIPTION
When compiling with gcc 8.4.1 I get
```
In file included from ../inode.h:9,
                 from ../inode.c:6:
../ondisk_format.h:228:72: error: expected ‘,’ before ‘)’ token
 static_assert(sizeof(struct btrfs_super_block) == BTRFS_SUPER_INFO_SIZE);
```
because static_assert requires two arguments in C11, so add a message to make it happy.